### PR TITLE
Added legacy peer dep flag.

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,5 +8,5 @@ ENV PATH /usr/src/app/client/.bin:$PATH
 
 COPY package.json /usr/src/app/client/package.json
 RUN npm install --silent
-RUN npm install react-scripts --silent
+RUN npm install react-scripts --legacy-peer-deps
 CMD ["npm", "start"]


### PR DESCRIPTION
Oneline fix to allow legacy peer dependencies on react-scripts. Without this an issue occurs that involves the dependency between typescript and react-scripts.