### PR TITLE
Added average statistics that gets publisher specific data.

### DIFF
--- a/anchor-api/lib/controllers/getStats.ts
+++ b/anchor-api/lib/controllers/getStats.ts
@@ -3,8 +3,8 @@ import Article from '../models/article.model';
 
 export function getAverageStats(request: express.Request, response: express.Response) {
   const field = request.params.field;
-
-  Article.aggregate([{ $group: { _id: null, average: { $avg: `$${field}` } } }], function (error: any, results: any) {
+//   const publisher = request.params.publisher;
+  Article.aggregate([{ $group: { _id: '$publisher', average: { $avg: `$${field}` } } }], function (error: any, results: any) {
     if (error) {
       response.status(403).send(error);
       throw error;

--- a/anchor-api/lib/index.ts
+++ b/anchor-api/lib/index.ts
@@ -32,7 +32,5 @@ app.get('/articles', getArticles);
 app.get(['/articles/search/:searchString', '/articles/search'], searchArticles);
 app.get('/stats/:field', getAverageStats);
 
-app.get('/sources', getSources);
-
 app.listen(PORT, HOST);
 console.log(`Listening on ${HOST}:${PORT}`);


### PR DESCRIPTION
Added API for publisher specific averages for objectivity, sentiment, and bias. This can be used to compare multiple sources by their classifications.

GET /stats/:<average_field>
Example Request: /stats/average_objectivity
Response:
[
    {
        "_id": "CNN",
        "average": 0.74383484383443
    },
    {
        "_id": "Fox News",
        "average": 0.575455210748173
    }
]
